### PR TITLE
✅ T2.1.1 Configure Auth0 backend integration (JWT validation)

### DIFF
--- a/backend/packages/backend/tests/routers/test_auth.py
+++ b/backend/packages/backend/tests/routers/test_auth.py
@@ -5,7 +5,63 @@ These use FastAPI's synchronous ``TestClient`` which wraps async endpoints.
 The default DB is an SQLite file configured by the environment.
 """
 
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
 from fastapi.testclient import TestClient
+
+from backend.auth import AuthMode
+
+# ---------------------------------------------------------------------------
+# Helpers — synthetic JWT payload used when mocking token verification
+# ---------------------------------------------------------------------------
+
+_FAKE_AUTH0_SUB = "auth0|63abc123def456"
+_FAKE_AUTH0_EMAIL = "testuser@example.com"
+
+
+def _fake_auth0_payload() -> dict:
+    return {
+        "sub": _FAKE_AUTH0_SUB,
+        "email": _FAKE_AUTH0_EMAIL,
+        "iss": "https://camply-test.us.auth0.com/",
+        "aud": "https://api.camply.juftin.dev",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — switch to Auth0 mode and optionally mock token verification
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def auth0_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Override ``CAMPLY_AUTH_MODE`` to ``auth0`` for the test scope."""
+    monkeypatch.setattr(
+        "backend.auth.backend_config.auth_mode",
+        AuthMode.AUTH0,
+    )
+
+
+@pytest.fixture
+def mock_auth0_verify() -> dict:
+    """Mock ``_verify_auth0_token`` so tests don't need real Auth0 keys."""
+    payload = _fake_auth0_payload()
+    patcher = patch(
+        "backend.auth._verify_auth0_token",
+        new=AsyncMock(return_value=payload),
+    )
+    patcher.start()
+    try:
+        yield payload
+    finally:
+        patcher.stop()
+
+
+# ===========================================================================
+# Local-mode tests (existing)
+# ===========================================================================
 
 
 class TestMeEndpoint:
@@ -52,3 +108,139 @@ class TestProvidersEndpoint:
         assert response.status_code == 200
         data = response.json()
         assert isinstance(data, list)
+
+
+# ===========================================================================
+# Auth0-mode tests
+# ===========================================================================
+
+
+class TestAuth0Mode:
+    """Tests for Auth0 JWT authentication."""
+
+    def test_auth0_missing_header_returns_401(
+        self,
+        auth0_mode: None,
+        test_client: TestClient,
+    ) -> None:
+        """Auth0 mode without a bearer token should return 401."""
+        response = test_client.get("/api/me")
+        assert response.status_code == 401
+        detail = response.json().get("detail", "")
+        assert "Missing Authorization header" in detail
+
+    def test_auth0_missing_header_on_scan_endpoint(
+        self,
+        auth0_mode: None,
+        test_client: TestClient,
+    ) -> None:
+        """Auth0 mode should also guard scan endpoints."""
+        response = test_client.get("/api/scans")
+        assert response.status_code == 401
+
+    def test_auth0_invalid_token_returns_401(
+        self,
+        auth0_mode: None,
+        test_client: TestClient,
+    ) -> None:
+        """An invalid or malformed JWT should return 401."""
+        response = test_client.get(
+            "/api/me",
+            headers={"Authorization": "Bearer this.is.not.a.valid.jwt"},
+        )
+        assert response.status_code == 401
+
+    def test_auth0_valid_token_returns_user(
+        self,
+        auth0_mode: None,
+        mock_auth0_verify: dict,
+        test_client: TestClient,
+    ) -> None:
+        """A valid (mocked) Auth0 JWT should return the user profile."""
+        response = test_client.get(
+            "/api/me",
+            headers={"Authorization": "Bearer valid_mocked_token"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["email"] == _FAKE_AUTH0_EMAIL
+        assert isinstance(uuid.UUID(data["id"]), uuid.UUID)
+        # New Auth0 users should not be early-access by default
+        assert data["is_early_access_user"] is False
+
+    def test_auth0_upserts_user(
+        self,
+        auth0_mode: None,
+        mock_auth0_verify: dict,
+        test_client: TestClient,
+    ) -> None:
+        """
+        Auth0 mode should create a DB user on first login and
+        return the same user on subsequent requests (upsert).
+        """
+        # First call — creates the user
+        resp1 = test_client.get(
+            "/api/me",
+            headers={"Authorization": "Bearer first_token"},
+        )
+        assert resp1.status_code == 200
+        user_id_1 = resp1.json()["id"]
+        assert resp1.json()["email"] == _FAKE_AUTH0_EMAIL
+
+        # Second call — should reuse the same user (same auth0_id / sub)
+        resp2 = test_client.get(
+            "/api/me",
+            headers={"Authorization": "Bearer second_token"},
+        )
+        assert resp2.status_code == 200
+        assert resp2.json()["id"] == user_id_1
+
+    def test_auth0_can_update_pushover(
+        self,
+        auth0_mode: None,
+        mock_auth0_verify: dict,
+        test_client: TestClient,
+    ) -> None:
+        """Auth0-mode users should be able to set pushover_token."""
+        response = test_client.patch(
+            "/api/me",
+            headers={"Authorization": "Bearer test_token"},
+            json={"pushover_token": "po_token_abc"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["pushover_token"] == "po_token_abc"
+
+    def test_auth0_public_endpoints_still_open(
+        self,
+        auth0_mode: None,
+        test_client: TestClient,
+    ) -> None:
+        """Public endpoints like health and providers work without auth."""
+        assert test_client.get("/api/health").status_code == 200
+        assert test_client.get("/api/providers").status_code == 200
+
+    def test_auth0_expired_token_returns_401(
+        self,
+        auth0_mode: None,
+        test_client: TestClient,
+    ) -> None:
+        """An expired JWT (simulated via mock) should return 401."""
+        from fastapi import HTTPException, status
+
+        with patch(
+            "backend.auth._verify_auth0_token",
+            new=AsyncMock(
+                side_effect=HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail="Token has expired",
+                )
+            ),
+        ):
+            response = test_client.get(
+                "/api/me",
+                headers={"Authorization": "Bearer expired_token"},
+            )
+        assert response.status_code == 401
+        detail = response.json().get("detail", "")
+        assert "expired" in detail.lower()

--- a/docs/agents/CHECKLIST.md
+++ b/docs/agents/CHECKLIST.md
@@ -58,7 +58,7 @@ This checklist tracks the granular progress of `camply`. Agents **MUST** update 
 
 ### 2.1 Authentication & Profile
 
-- [ ] T2.1.1 Configure Auth0 backend integration (JWT validation).
+- [x] T2.1.1 Configure Auth0 backend integration (JWT validation).
 - [ ] T2.1.2 Implement `is_early_access_user` middleware for FastAPI.
 - [ ] T2.1.3 Configure Auth0 frontend integration (React SDK).
 - [ ] T2.1.4 Build the User Profile page for Pushover key management.


### PR DESCRIPTION
Closes #14

## What

Writes comprehensive unit tests for the Auth0 authentication mode in the FastAPI backend and marks T2.1.1 as complete in the checklist.

## Changes

- **`backend/packages/backend/tests/routers/test_auth.py`** — 8 new Auth0-mode tests:
  - Missing bearer token → 401
  - Invalid/malformed JWT → 401
  - Expired token → 401
  - Valid (mocked) JWT → returns user profile
  - User upsert (same `auth0_id` → same DB user)
  - Pushover token updates in Auth0 mode
  - Public endpoints (health, providers) remain open
  - Scans endpoint also guarded by Auth0
- **`docs/agents/CHECKLIST.md`** — Mark T2.1.1 as `[x]`

## Quality Gates

- ✅ 31/31 tests passing (23 existing + 8 new)
- ✅ `ruff check` clean
- ✅ `ruff format` clean
- ✅ `mypy` clean (0 issues in 75 source files)

## Notes

The core Auth0 JWT validation logic (`_verify_auth0_token`, config fields, user upsert) was already implemented in Phase 1.4 (PR #12). This PR adds the missing test coverage and formally closes the issue.