### PR TITLE
🐛 (db): add merge migration for diverging checklist and access_request heads

### DIFF
--- a/backend/packages/db/migrations/versions/77984a1ae368_merge_checklist_and_access_request.py
+++ b/backend/packages/db/migrations/versions/77984a1ae368_merge_checklist_and_access_request.py
@@ -1,0 +1,29 @@
+"""
+merge_checklist_and_access_request
+
+Revision ID: 77984a1ae368
+Revises: 36b6b307eef5, abc123access
+Create Date: 2026-06-08 04:12:00.953725+00:00
+"""
+
+from typing import Sequence, Union
+
+# revision identifiers, used by Alembic.
+revision: str = "77984a1ae368"
+down_revision: Union[str, Sequence[str], None] = ("36b6b307eef5", "abc123access")
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """
+    Upgrade schema.
+    """
+    pass
+
+
+def downgrade() -> None:
+    """
+    Downgrade schema.
+    """
+    pass


### PR DESCRIPTION
## Summary

Adds a merge migration to reconcile two diverging Alembic revision heads (`36b6b307eef5` and `abc123access`) created during parallel development.

## Context

Two migrations were generated independently, resulting in a branching revision tree. This no-op merge migration resolves that split so the migration chain is linear going forward.

## Changes

- **`backend/packages/db/migrations/versions/77984a1ae368_merge_checklist_and_access_request.py`**
  - New merge migration with no-op upgrade/downgrade, pointing to both parent revisions.