### PR TITLE
📝 (docs): update free-and-open-source language

### DIFF
--- a/frontend/src/pages/Contribute.tsx
+++ b/frontend/src/pages/Contribute.tsx
@@ -5,7 +5,6 @@ import {
   Bell,
   Shield,
   DollarSign,
-  ExternalLink,
   HeartHandshake,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -47,28 +46,14 @@ export function Contribute() {
           </CardHeader>
           <CardContent className="text-center space-y-4">
             <p className="text-lg font-medium">
-              We personally commit to <strong>never taking any profit</strong>{" "}
-              from camply.
+              We are committed to <strong>keeping camply free</strong> and
+              open-source, forever.
             </p>
             <p className="text-muted-foreground">
-              100% of all contributions go directly towards maintaining the
-              service, covering hosting costs, notification delivery, and
-              keeping the lights on. This is a labor of love for the outdoor
-              community, not a business venture.
+              Contributions help cover hosting costs, notification delivery, and
+              ongoing development. This is a labor of love for the outdoor
+              community.
             </p>
-            <div className="text-sm text-muted-foreground mt-4">
-              <span className="text-center">
-                All expenses are tracked transparently on our{" "}
-                <a
-                  href="https://github.com/juftin/camply"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-primary hover:text-primary/80 font-medium"
-                >
-                  GitHub repository
-                </a>
-              </span>
-            </div>
           </CardContent>
         </Card>
       </section>
@@ -299,69 +284,6 @@ export function Contribute() {
             </CardContent>
           </Card>
         </div>
-      </section>
-
-      {/* Transparency */}
-      <section className="mb-16">
-        <Card>
-          <CardHeader className="text-center">
-            <CardTitle className="text-2xl">
-              Transparency & Accountability
-            </CardTitle>
-            <CardDescription>
-              We believe in complete transparency about how contributions are
-              used
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-6">
-            <div className="text-center">
-              <p className="text-muted-foreground mb-4">
-                As camply grows, we are committed to maintaining complete
-                transparency about operational costs and how contributions are
-                used. All financial information will be shared openly with the
-                community.
-              </p>
-            </div>
-
-            <div className="grid md:grid-cols-2 gap-8">
-              <div>
-                <h4 className="font-semibold mb-3">
-                  Our Commitment to Transparency
-                </h4>
-                <ul className="space-y-2 text-muted-foreground">
-                  <li>• All expenses tracked and documented</li>
-                  <li>• Regular financial updates to the community</li>
-                  <li>• Open-source approach to financial management</li>
-                  <li>• Zero profit guarantee - all funds go to operations</li>
-                  <li>• Community input on major expenditures</li>
-                </ul>
-              </div>
-              <div>
-                <h4 className="font-semibold mb-3">What We'll Track</h4>
-                <ul className="space-y-2 text-muted-foreground">
-                  <li>• Server and hosting costs</li>
-                  <li>• Email and notification service fees</li>
-                  <li>• Database and storage expenses</li>
-                  <li>• Third-party service integrations</li>
-                  <li>• Any infrastructure improvements</li>
-                </ul>
-              </div>
-            </div>
-
-            <div className="text-center pt-4">
-              <Button variant="outline" asChild>
-                <a
-                  href="https://github.com/juftin/camply"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <ExternalLink className="h-4 w-4 mr-2" />
-                  Follow Our Progress on GitHub
-                </a>
-              </Button>
-            </div>
-          </CardContent>
-        </Card>
       </section>
 
       {/* Thank You */}

--- a/frontend/src/pages/FAQ.tsx
+++ b/frontend/src/pages/FAQ.tsx
@@ -27,7 +27,7 @@ const faqs: FAQItem[] = [
     id: "is-free",
     question: "Is camply free to use?",
     answer:
-      "Yes! camply is completely free and open-source. We operate as a not-for-profit service supported by community contributions. There are no hidden fees or premium subscriptions.",
+      "Yes! camply is completely free and open-source, supported by community contributions. There are no hidden fees or premium subscriptions.",
   },
   {
     id: "make-reservations",

--- a/frontend/src/pages/PrivacyPolicy.tsx
+++ b/frontend/src/pages/PrivacyPolicy.tsx
@@ -16,12 +16,10 @@ export function PrivacyPolicy() {
             availability monitoring service.
           </p>
           <p className="mb-4 p-4 bg-primary/10 border border-primary/20 rounded-lg">
-            <strong>Our Commitment:</strong> camply is operated as a
-            not-for-profit service. We will{" "}
-            <strong>never sell your personal data</strong> to third parties or
-            use it for commercial gain. Our mission is to help outdoor
-            enthusiasts find campsites, and we are committed to operating
-            ethically and transparently.
+            <strong>Our Commitment:</strong> camply is a free service. We will{" "}
+            <strong>never sell your personal data</strong> to third parties.
+            Our mission is to help outdoor enthusiasts find campsites, and we
+            are committed to operating ethically and transparently.
           </p>
         </section>
 
@@ -65,10 +63,10 @@ export function PrivacyPolicy() {
         <section className="mb-8">
           <h2 className="text-2xl font-semibold mb-4">Information Sharing</h2>
           <p className="mb-4">
-            <strong>We will never sell your personal data.</strong> As a
-            not-for-profit service, we do not sell, trade, rent, or monetize
-            your personal information in any way. We may share your information
-            only in the following limited circumstances:
+            <strong>We will never sell your personal data.</strong> We do not
+            sell, trade, rent, or monetize your personal information in any
+            way. We may share your information only in the following limited
+            circumstances:
           </p>
           <ul className="list-disc list-inside mb-4 space-y-2">
             <li>With your explicit consent</li>
@@ -79,11 +77,6 @@ export function PrivacyPolicy() {
               (email delivery, hosting) under strict confidentiality agreements
             </li>
           </ul>
-          <p className="mb-4 text-sm text-muted-foreground">
-            <strong>Note:</strong> Given our not-for-profit nature, we have no
-            plans for business transfers or mergers that would involve sharing
-            your data.
-          </p>
         </section>
 
         <section className="mb-8">
@@ -174,8 +167,8 @@ export function PrivacyPolicy() {
             </li>
           </ul>
           <p className="mb-4 text-sm text-muted-foreground">
-            As an open-source, not-for-profit project, we welcome transparency
-            and community feedback on our privacy practices.
+            As an open-source project, we welcome transparency and community
+            feedback on our privacy practices.
           </p>
         </section>
       </div>

--- a/frontend/src/pages/TermsOfService.tsx
+++ b/frontend/src/pages/TermsOfService.tsx
@@ -29,8 +29,7 @@ export function TermsOfService() {
             become available based on your preferences.
           </p>
           <p className="mb-4 p-4 bg-primary/10 border border-primary/20 rounded-lg">
-            <strong>Not-for-Profit Service:</strong> camply is operated as a
-            not-for-profit service with a mission to help outdoor enthusiasts
+            camply is a free service with a mission to help outdoor enthusiasts
             access nature. We are committed to ethical practices and will never
             monetize your personal data.
           </p>
@@ -128,10 +127,9 @@ export function TermsOfService() {
             lost revenue, or lost data, arising from your use of the service.
           </p>
           <p className="mb-4">
-            As a not-for-profit service, our liability is limited to the extent
-            permitted by law. We provide this service to help the outdoor
-            community and operate in good faith to maintain reliable campsite
-            monitoring.
+            Our liability is limited to the extent permitted by law. We provide
+            this service to help the outdoor community and operate in good
+            faith to maintain reliable campsite monitoring.
           </p>
         </section>
 
@@ -167,8 +165,8 @@ export function TermsOfService() {
             Privacy and Data Ethics
           </h2>
           <p className="mb-4">
-            Your privacy is important to us. As a not-for-profit service, we are
-            committed to ethical data practices:
+            Your privacy is important to us. We are committed to ethical data
+            practices:
           </p>
           <ul className="list-disc list-inside mb-4 space-y-2">
             <li>
@@ -256,8 +254,8 @@ export function TermsOfService() {
             </li>
           </ul>
           <p className="mb-4 text-sm text-muted-foreground">
-            As an open-source, not-for-profit project, we encourage transparency
-            and welcome community feedback on our terms and operations.
+            As an open-source project, we encourage transparency and welcome
+            community feedback on our terms and operations.
           </p>
         </section>
       </div>


### PR DESCRIPTION
## Summary

Removes all "not-for-profit" framing from public-facing pages, replacing it with simpler "free and open-source" messaging. Also removes the financial transparency section from the contribute page.

## Context

Camply is free and open-source forever, but the "not-for-profit" label was overly restrictive — the project may eventually sustain itself. This update keeps the commitment to free + open while removing language that implies a specific financial structure.

## Changes

- **`frontend/src/pages/PrivacyPolicy.tsx`** — Replaced "not-for-profit service" with "free service" in the commitment callout, data-sharing section, and contact section. Removed paragraph about no plans for business transfers.
- **`frontend/src/pages/TermsOfService.tsx`** — Removed "Not-for-Profit Service" heading from callout; dropped "not-for-profit" from liability, privacy ethics, and contact sections.
- **`frontend/src/pages/FAQ.tsx`** — Simplified "Is camply free?" to say "completely free and open-source, supported by community contributions."
- **`frontend/src/pages/Contribute.tsx`** — Replaced profit-related commitment language with "keeping camply free and open-source, forever." Removed financial transparency section.