### PR TITLE
♻️ Remove redundant Dashboard/Profile links from main nav

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -117,28 +117,6 @@ export function Header({ showLogo = true }: HeaderProps) {
             >
               Contribute
             </Link>
-            {isAuthenticated && isEarlyAccess && (
-              <>
-                <Link
-                  to="/dashboard"
-                  className={`flex items-center gap-1 text-muted-foreground hover:text-foreground ${
-                    location.pathname === "/dashboard" ? "text-foreground" : ""
-                  }`}
-                >
-                  <LayoutDashboard className="h-4 w-4" />
-                  Dashboard
-                </Link>
-                <Link
-                  to="/profile"
-                  className={`flex items-center gap-1 text-muted-foreground hover:text-foreground ${
-                    location.pathname === "/profile" ? "text-foreground" : ""
-                  }`}
-                >
-                  <User className="h-4 w-4" />
-                  Profile
-                </Link>
-              </>
-            )}
           </nav>
 
           <button
@@ -230,30 +208,6 @@ export function Header({ showLogo = true }: HeaderProps) {
             >
               Contribute
             </Link>
-            {isAuthenticated && isEarlyAccess && (
-              <>
-                <Link
-                  to="/dashboard"
-                  className={`block text-muted-foreground hover:text-foreground ${
-                    location.pathname === "/dashboard" ? "text-foreground" : ""
-                  }`}
-                  onClick={() => setIsMobileMenuOpen(false)}
-                >
-                  <LayoutDashboard className="h-4 w-4 inline mr-1" />
-                  Dashboard
-                </Link>
-                <Link
-                  to="/profile"
-                  className={`block text-muted-foreground hover:text-foreground ${
-                    location.pathname === "/profile" ? "text-foreground" : ""
-                  }`}
-                  onClick={() => setIsMobileMenuOpen(false)}
-                >
-                  <User className="h-4 w-4 inline mr-1" />
-                  Profile
-                </Link>
-              </>
-            )}
             <div className="pt-4 border-t space-y-3">
               <div className="flex items-center justify-between">
                 <ThemeToggle />


### PR DESCRIPTION
## Summary

Remove Dashboard and Profile links from the main navigation bar. These are redundant since Dashboard and Profile are already accessible from the user dropdown menu in the top-right corner.

## Context

When logged in, Dashboard and Profile appeared in both the main nav (alongside Providers, Ethos, Contribute) and as icon buttons next to the ThemeToggle. This deduplicates the navigation so they only appear in the right-side button area.

## Changes

- **`frontend/src/components/Header.tsx`**
  - Removed Dashboard and Profile `<Link>` entries from the desktop nav bar
  - Removed Dashboard and Profile `<Link>` entries from the mobile nav menu
  - Kept the Dashboard and Profile `<Button>` components next to ThemeToggle (desktop and mobile)

## Test Plan

- [x] Lint and type check pass
- [ ] Manual verification: confirm Dashboard/Profile no longer appear in main nav links when logged in
- [ ] Manual verification: confirm Dashboard/Profile buttons still appear next to ThemeToggle