### PR TITLE
🔧 Add Celery worker multiprocess Prometheus metrics and monitoring healthchecks

### DIFF
--- a/backend/docker-compose.yaml
+++ b/backend/docker-compose.yaml
@@ -32,6 +32,10 @@ services:
     depends_on:
       db:
         condition: service_healthy
+      prometheus:
+        condition: service_healthy
+      grafana:
+        condition: service_healthy
     volumes:
       - "${HOME}/Application\ Support/camply/:/root/.local/share/camply/"
     environment:
@@ -82,6 +86,10 @@ services:
         condition: service_healthy
       valkey:
         condition: service_healthy
+      prometheus:
+        condition: service_healthy
+      grafana:
+        condition: service_healthy
     volumes:
       - "${HOME}/Application\ Support/camply/:/root/.local/share/camply/"
     environment:
@@ -110,6 +118,10 @@ services:
         condition: service_healthy
       valkey:
         condition: service_healthy
+      prometheus:
+        condition: service_healthy
+      grafana:
+        condition: service_healthy
     volumes:
       - "${HOME}/Application\ Support/camply/:/root/.local/share/camply/"
     environment:
@@ -134,6 +146,12 @@ services:
       - "--web.console.libraries=/usr/share/prometheus/console_libraries"
       - "--web.console.templates=/usr/share/prometheus/consoles"
       - "--storage.tsdb.retention.time=30d"
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:9090/-/healthy"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
     ports:
       - "9090:9090"
     volumes:
@@ -147,6 +165,12 @@ services:
       GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:-admin}
       GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-camply}
       GF_AUTH_ANONYMOUS_ENABLED: "true"
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://localhost:3000/api/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
     ports:
       - "3000:3000"
     volumes:

--- a/backend/docker-compose.yaml
+++ b/backend/docker-compose.yaml
@@ -103,6 +103,8 @@ services:
       CAMPLY_SENTRY_DSN: ${SENTRY_DSN:-}
       CAMPLY_SENTRY_TRACES_SAMPLE_RATE: ${SENTRY_TRACES_SAMPLE_RATE:-0.0}
       CAMPLY_METRICS_PORT: 8001
+      PROMETHEUS_MULTIPROC_DIR: "/tmp/prometheus_multiproc"
+      CAMPLY_PROMETHEUS_MULTIPROC_DIR: "/tmp/prometheus_multiproc"
       PUSHOVER_APP_TOKEN: ${PUSHOVER_APP_TOKEN:-}
       SKIP_MIGRATIONS: "1"
     restart: unless-stopped
@@ -136,6 +138,8 @@ services:
       CAMPLY_SENTRY_TRACES_SAMPLE_RATE: ${SENTRY_TRACES_SAMPLE_RATE:-0.0}
       SKIP_MIGRATIONS: "1"
       CAMPLY_METRICS_PORT: 8001
+      PROMETHEUS_MULTIPROC_DIR: "/tmp/prometheus_multiproc"
+      CAMPLY_PROMETHEUS_MULTIPROC_DIR: "/tmp/prometheus_multiproc"
     restart: unless-stopped
 
   prometheus:

--- a/backend/docker-compose.yaml
+++ b/backend/docker-compose.yaml
@@ -32,10 +32,6 @@ services:
     depends_on:
       db:
         condition: service_healthy
-      prometheus:
-        condition: service_healthy
-      grafana:
-        condition: service_healthy
     volumes:
       - "${HOME}/Application\ Support/camply/:/root/.local/share/camply/"
     environment:
@@ -86,10 +82,6 @@ services:
         condition: service_healthy
       valkey:
         condition: service_healthy
-      prometheus:
-        condition: service_healthy
-      grafana:
-        condition: service_healthy
     volumes:
       - "${HOME}/Application\ Support/camply/:/root/.local/share/camply/"
     environment:
@@ -119,10 +111,6 @@ services:
       db:
         condition: service_healthy
       valkey:
-        condition: service_healthy
-      prometheus:
-        condition: service_healthy
-      grafana:
         condition: service_healthy
     volumes:
       - "${HOME}/Application\ Support/camply/:/root/.local/share/camply/"

--- a/backend/packages/worker/worker/celery_app.py
+++ b/backend/packages/worker/worker/celery_app.py
@@ -5,7 +5,7 @@ Celery Application Configuration
 import structlog
 from celery import Celery
 from celery.schedules import crontab
-from celery.signals import setup_logging, worker_ready
+from celery.signals import setup_logging, worker_init
 
 from worker.config import worker_config
 
@@ -76,7 +76,6 @@ def configure_celery_logging(**kwargs: object) -> None:
     """
     structlog.configure(
         processors=[
-            structlog.stdlib.filter_by_level,
             structlog.stdlib.add_logger_name,
             structlog.stdlib.add_log_level,
             structlog.stdlib.PositionalArgumentsFormatter(),
@@ -88,7 +87,7 @@ def configure_celery_logging(**kwargs: object) -> None:
         ],
         wrapper_class=structlog.stdlib.BoundLogger,
         context_class=dict,
-        logger_factory=structlog.PrintLoggerFactory(),
+        logger_factory=structlog.stdlib.LoggerFactory(),
         cache_logger_on_first_use=True,
     )
 
@@ -99,13 +98,17 @@ celery_app = create_celery_app()
 import worker.metrics  # noqa: E402, F401
 
 
-@worker_ready.connect
-def _on_worker_ready(**kwargs: object) -> None:
-    """Start the Prometheus metrics HTTP server when the worker is ready."""
-    if worker_config.metrics_port > 0:
-        from worker.metrics import start_metrics_server_in_thread
+@worker_init.connect
+def _on_worker_init(**kwargs: object) -> None:
+    """Start the Prometheus metrics HTTP server when the worker initializes.
 
-        start_metrics_server_in_thread(port=worker_config.metrics_port)
+    Uses worker_init (main process, before pool fork) rather than
+    worker_ready so the metrics server is ready before children start.
+    """
+    if worker_config.metrics_port > 0:
+        from worker.metrics import start_metrics_server
+
+        start_metrics_server(port=worker_config.metrics_port)
 
 
 # Conditional Sentry initialization

--- a/backend/packages/worker/worker/metrics.py
+++ b/backend/packages/worker/worker/metrics.py
@@ -147,12 +147,13 @@ def start_metrics_server(port: int = 8001) -> None:
     Otherwise falls back to the default in-process collector for single-worker
     setups (e.g. local development with --pool=solo).
     """
-    registry = prometheus_client.CollectorRegistry()
-    if _multiproc_dir:
-        MultiProcessCollector(registry)
-
     try:
-        prometheus_client.start_http_server(port, registry=registry)
+        if _multiproc_dir:
+            registry = prometheus_client.CollectorRegistry()
+            MultiProcessCollector(registry)
+            prometheus_client.start_http_server(port, registry=registry)
+        else:
+            prometheus_client.start_http_server(port)
         logger.info("Worker metrics server started", port=port)
     except Exception:
         logger.exception("Failed to start worker metrics server", port=port)

--- a/backend/packages/worker/worker/metrics.py
+++ b/backend/packages/worker/worker/metrics.py
@@ -5,16 +5,38 @@ Exposes a /metrics endpoint on a separate HTTP port (default 8001)
 via prometheus_client's built-in HTTP server running in a daemon thread.
 Celery signals (task_prerun, task_postrun) automatically capture task
 execution counts and durations across all tasks.
+
+When PROMETHEUS_MULTIPROC_DIR is set, uses prometheus_client's multiprocess
+mode so metrics from all prefork worker children are aggregated via shared
+.db files, matching the FastAPI backend's approach.
 """
 
-import threading
+import os
 import time
 from typing import Any
 
-import prometheus_client
 import structlog
 from celery.signals import task_postrun, task_prerun
-from prometheus_client import Counter, Gauge, Histogram
+
+# Must create the multiprocess directory BEFORE prometheus_client is first
+# imported — the library checks the env var at import time.
+_multiproc_dir = os.environ.get(
+    "CAMPLY_PROMETHEUS_MULTIPROC_DIR",
+    os.environ.get("PROMETHEUS_MULTIPROC_DIR"),
+)
+if _multiproc_dir:
+    os.makedirs(_multiproc_dir, exist_ok=True)
+    # Clean stale .db files from previous runs to prevent metric accumulation
+    for fname in os.listdir(_multiproc_dir):
+        if fname.endswith(".db"):
+            try:
+                os.remove(os.path.join(_multiproc_dir, fname))
+            except OSError:
+                pass
+
+import prometheus_client  # noqa: E402
+from prometheus_client import Counter, Gauge, Histogram  # noqa: E402
+from prometheus_client.multiprocess import MultiProcessCollector  # noqa: E402
 
 logger = structlog.getLogger(__name__)
 
@@ -120,28 +142,17 @@ def start_metrics_server(port: int = 8001) -> None:
     """
     Start a prometheus_client HTTP server in a daemon thread.
 
-    Runs on the given port so Prometheus can scrape worker metrics
-    independently from the backend API.
+    When PROMETHEUS_MULTIPROC_DIR is configured, uses MultiProcessCollector
+    to aggregate metrics from all prefork worker children via shared .db files.
+    Otherwise falls back to the default in-process collector for single-worker
+    setups (e.g. local development with --pool=solo).
     """
+    registry = prometheus_client.CollectorRegistry()
+    if _multiproc_dir:
+        MultiProcessCollector(registry)
+
     try:
-        prometheus_client.start_http_server(port)
+        prometheus_client.start_http_server(port, registry=registry)
         logger.info("Worker metrics server started", port=port)
     except Exception:
         logger.exception("Failed to start worker metrics server", port=port)
-
-
-def start_metrics_server_in_thread(port: int = 8001) -> None:
-    """
-    Start the metrics HTTP server in a daemon thread.
-
-    This is safe to call from within a Celery worker process. The thread
-    is marked daemon so it won't block shutdown.
-    """
-    thread = threading.Thread(
-        target=start_metrics_server,
-        args=(port,),
-        daemon=True,
-        name="prometheus-metrics",
-    )
-    thread.start()
-    logger.info("Worker metrics server thread started", port=port)


### PR DESCRIPTION
## Summary

Add Prometheus and Grafana healthchecks, enable multiprocess Prometheus metrics for the Celery worker, and fix an issue where Celery task metrics were invisible because prefork child processes couldn't share their metrics with the main process.

## Context

The Celery worker runs with `--concurrency=4` (prefork pool). Even though the Prometheus metrics HTTP server started correctly in the main process, all task metrics (counters, histograms) were incremented in child processes — invisible to the main process serving `/metrics`. Prometheus scraped zeros. Grafana showed no Celery data.

This implements `prometheus_client` multiprocess mode (matching the FastAPI backend's approach) where each worker child writes metrics to shared `.db` files, and a `MultiProcessCollector` in the main process aggregates them.

## Changes

- **`backend/docker-compose.yaml`** — Add healthchecks for Prometheus (`/-/healthy`) and Grafana (`/api/health`); add `PROMETHEUS_MULTIPROC_DIR` and `CAMPLY_PROMETHEUS_MULTIPROC_DIR` env vars to celery-worker and celery-beat
- **`backend/packages/worker/worker/metrics.py`** — Create multiproc directory before `prometheus_client` import, clean stale `.db` files on startup, use `MultiProcessCollector` in the metrics server, fall back to default collector when multiproc dir is unset (local dev)
- **`backend/packages/worker/worker/celery_app.py`** — Switch from `worker_ready` to `worker_init` signal (fires in main process before pool fork); fix structlog configuration to use `LoggerFactory` instead of `PrintLoggerFactory`

## Test Plan

- [x] All files reviewed by agent and manually verified
- [ ] `docker compose up -d celery-worker` — worker starts, metrics server on port 8001
- [ ] `docker compose exec celery-worker curl -s http://localhost:8001/metrics | grep camply_celery_tasks_total` — non-zero values after task execution
- [ ] Prometheus targets at `localhost:9090/targets` — `camply-worker` shows UP
- [ ] Grafana dashboard shows Celery task metrics (previously empty)
- [ ] `docker compose exec prometheus wget -qO- http://localhost:9090/-/healthy` → `Healthy`
- [ ] `docker compose exec grafana wget -qO- http://localhost:3000/api/health` → `ok`
